### PR TITLE
feat: Implement CRUD operations for Empresa entity

### DIFF
--- a/app/routers/empresa.py
+++ b/app/routers/empresa.py
@@ -1,38 +1,77 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
-from typing import List
+from sqlalchemy.orm import Session
+from typing import List, Optional
 
-router = APIRouter(prefix="/empresa")
+from database import get_db
+from app.models.empresa import Empresa as EmpresaModel
 
-class CompanyResponse(BaseModel):
-    id: int
+router = APIRouter(prefix="/empresa", tags=["empresas"])
+
+# Pydantic Models
+class CompanyBase(BaseModel):
     cnpj: str
     razao_social: str
-    email_contato: str
+    nome_fantasia: Optional[str] = None
+    numero_contato: Optional[str] = None
+    email_contato: Optional[str] = None
+    website: Optional[str] = None
+
+class CompanyCreate(CompanyBase):
+    pass
+
+class CompanyUpdate(CompanyBase):
+    cnpj: Optional[str] = None # All fields optional for update
+    razao_social: Optional[str] = None
+    # Other fields are already optional in CompanyBase
+
+class CompanyResponse(CompanyBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+# CRUD Endpoints
+@router.post("/", response_model=CompanyResponse, status_code=status.HTTP_201_CREATED)
+def criar_empresa(empresa: CompanyCreate, db: Session = Depends(get_db)):
+    db_empresa = EmpresaModel(**empresa.dict())
+    db.add(db_empresa)
+    db.commit()
+    db.refresh(db_empresa)
+    return db_empresa
+
+@router.get("/", response_model=List[CompanyResponse])
+def listar_empresas(db: Session = Depends(get_db)):
+    empresas = db.query(EmpresaModel).all()
+    return empresas
+
+@router.get("/{id}", response_model=CompanyResponse)
+def obter_empresa(id: int, db: Session = Depends(get_db)):
+    empresa = db.query(EmpresaModel).filter(EmpresaModel.id == id).first()
+    if empresa is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Empresa não encontrada")
+    return empresa
+
+@router.put("/{id}", response_model=CompanyResponse)
+def atualizar_empresa(id: int, empresa_update: CompanyUpdate, db: Session = Depends(get_db)):
+    db_empresa = db.query(EmpresaModel).filter(EmpresaModel.id == id).first()
+    if db_empresa is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Empresa não encontrada")
+
+    update_data = empresa_update.dict(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(db_empresa, key, value)
     
+    db.commit()
+    db.refresh(db_empresa)
+    return db_empresa
 
-@router.get("/", response_model=List[CompanyResponse], response_description="Essa rota lista todas as bibliotecas que existem")
-def listar_empresas():
-    return [
-        CompanyResponse(
-            id = 1,
-            cnpj = "12345678912345",
-            razao_social = "Empresa Teste Ltda.",
-            email_contato = "contato@teste.com"
-        )
-    ]
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+def deletar_empresa(id: int, db: Session = Depends(get_db)):
+    db_empresa = db.query(EmpresaModel).filter(EmpresaModel.id == id).first()
+    if db_empresa is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Empresa não encontrada")
 
-@router.post("/")
-def criar_empresas():
-    return [
-        {"id": 1,
-         "cnpj": "12345678912345",
-         "razao_social": "Empresa Teste Ltda.",
-         "email_contato": "contato@teste.com"
-         },
-        {"id": 2,
-         "cnpj": "98765432198712",
-         "razao_social": "Empresa ABC",
-         "email_contato": "contato@abc.com.br"
-         },
-    ]
+    db.delete(db_empresa)
+    db.commit()
+    return None

--- a/main.py
+++ b/main.py
@@ -6,6 +6,9 @@ from app.models import cargo, cliente, copias_livro, empresa, emprestimo, endere
 
 app = FastAPI()
 
+# Include the empresa router
+app.include_router(empresa.router)
+
 #Limpa o banco e gera um novo
 
 Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
I've added full CRUD (Create, Read, Update, Delete) functionality for the Empresa (Company) entity in your project.

Here's a summary of the key changes I made:
- I defined Pydantic models (`CompanyCreate`, `CompanyUpdate`, `CompanyResponse`) in `app/routers/empresa.py`. These will help with validating and serializing data for requests and responses.
- I implemented the FastAPI route handlers in `app/routers/empresa.py` for the following operations:
    - POST /empresa/ : This will allow you to create a new company.
    - GET /empresa/ : This will list all companies.
    - GET /empresa/{id} : This will let you retrieve a specific company using its ID.
    - PUT /empresa/{id} : You can use this to update a specific company by its ID.
    - DELETE /empresa/{id} : This will allow you to delete a specific company by its ID.
- I connected these operations to your SQLAlchemy `Empresa` model and database session management (`get_db`).
- I included the `empresa` router in the main FastAPI application in `main.py`.
- I also made sure all necessary dependencies are correctly imported.